### PR TITLE
Fix[#21] : chargement du composant Front

### DIFF
--- a/custom_components/sncf_trains/__init__.py
+++ b/custom_components/sncf_trains/__init__.py
@@ -2,9 +2,10 @@
 
 from pathlib import Path
 from types import MappingProxyType
+from logging import getLogger
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, CoreState, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.helpers.entity_registry import Platform
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.http import StaticPathConfig
@@ -30,14 +31,29 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 CARD_URL = "/sncf_trains/sncf-train-card.js"
 CARD_FILE = Path(__file__).parent / "www" / "sncf-train-card.js"
+LOGGER = getLogger(__name__)
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up SNCF Trains component — register the Lovelace card."""
-    await hass.http.async_register_static_paths(
-        [StaticPathConfig(CARD_URL, str(CARD_FILE), cache_headers=False)]
-    )
-    add_extra_js_url(hass, CARD_URL)
+    async def _setup_frontend(_event: Any = None) -> None:
+        """Inner function to register frontend modules."""
+        await hass.http.async_register_static_paths(
+            [StaticPathConfig(CARD_URL, str(CARD_FILE), cache_headers=False)]
+        )
+        add_extra_js_url(hass, CARD_URL)
+
+    if hass.state == CoreState.running:
+        LOGGER.debug(
+            "Home Assistant already running, registering frontend modules immediately."
+        )
+        await _setup_frontend()
+    else:
+        LOGGER.debug(
+            "Home Assistant not running yet, scheduling frontend module registration."
+        )
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _setup_frontend)
+
     return True
 
 


### PR DESCRIPTION
L'intégration tente d'instancier le composant front avant que le core d'Home Assistant soit complètement initié ce qui provoque une erreur (invisible) à son initialisation.

Je m'en suis rendu compte en comparant le chargement du module front avec le repo [marees_france](https://github.com/KipK/marees_france) de [KipK](https://github.com/KipK), merci à lui.

Closes Issue #21